### PR TITLE
add port forwarding for CacheServer

### DIFF
--- a/composer/docker-compose.yml
+++ b/composer/docker-compose.yml
@@ -26,8 +26,7 @@ server:
    - "40404"
    - "1099"
   ports:
-   - "40404"
+   - "40404:40404"
   volumes:
    - ./scripts/:/scripts/
-   #- scripts/:/data/
   command: /scripts/startServer.sh --server-port=40404 --hostname-for-clients=192.168.99.100 --max-heap=1G


### PR DESCRIPTION
add the cache server port forwarding to the docker-compose
configuration.

Gemfire can now be accessed from the host machine (via 192.168.99.100).

Tested on Windows only....
